### PR TITLE
fix: improve code block copy button styling

### DIFF
--- a/website/src/lib/components/CodeBlock.svelte
+++ b/website/src/lib/components/CodeBlock.svelte
@@ -14,13 +14,18 @@
 <div class="bg-white rounded-md border border-gray-200 p-4 relative">
   <pre class="text-sm overflow-x-auto"><code>{code}</code></pre>
   <button
-    onclick={() => onCopy(code, copyKey)}
-    class="absolute right-3 top-3 p-1.5 rounded hover:bg-gray-100"
-  >
-    {#if copyStatus[copyKey] === "success"}
-      <Check class="w-4 h-4 text-green-600" />
-    {:else}
-      <Copy class="w-4 h-4 text-gray-500" />
-    {/if}
-  </button>
+  onclick={() => onCopy(code, copyKey)}
+  aria-label="Copy code"
+  class="absolute top-3 right-3 flex h-8 w-8 items-center justify-center
+       rounded-md border border-gray-200 bg-white
+       text-gray-500 shadow-sm
+       transition-colors
+       hover:bg-gray-50 hover:text-gray-900"
+>
+  {#if copyStatus[copyKey] === "success"}
+    <Check class="h-4 w-4 text-green-600" />
+  {:else}
+    <Copy class="h-4 w-4" />
+  {/if}
+</button>
 </div>


### PR DESCRIPTION
## Summary
- Improves the code block copy button styling on the website.

## Changes
- Added a border and background to the copy button.

## Before

https://github.com/user-attachments/assets/b234170b-fd25-41de-9771-d379e9822515

## After

https://github.com/user-attachments/assets/a9bc212c-b711-42cf-986d-007492a147a9


